### PR TITLE
Possibility to disable the automatic conversion of sources to HTTPS

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -40,6 +40,11 @@ class CSPBuilder
     protected $supportOldBrowsers = true;
 
     /**
+     * @var bool
+     */
+    protected $httpsTransformOnHttpsConnections = true;
+
+    /**
      * @var string[]
      */
     private static $directives = [
@@ -506,7 +511,7 @@ class CSPBuilder
                 if ($url !== false) {
                     if ($this->supportOldBrowsers) {
                         if (\strpos($url, '://') === false) {
-                            if ($this->isHTTPSConnection() || !empty($this->policies['upgrade-insecure-requests'])) {
+                            if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections) || !empty($this->policies['upgrade-insecure-requests'])) {
                                 // We only want HTTPS connections here.
                                 $ret .= 'https://'.$url.' ';
                             } else {
@@ -514,7 +519,7 @@ class CSPBuilder
                             }
                         }
                     }
-                    if ($this->isHTTPSConnection() || !empty($this->policies['upgrade-insecure-requests'])) {
+                    if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections) || !empty($this->policies['upgrade-insecure-requests'])) {
                         $ret .= \str_replace('http://', 'https://', $url).' ';
                     } else {
                         $ret .= $url.' ';
@@ -603,5 +608,33 @@ class CSPBuilder
             return $_SERVER['HTTPS'] !== 'off';
         }
         return false;
+    }
+
+    /**
+     * Disable that HTTP sources get converted to HTTPS if the connection is such.
+     *
+     * @return CSPBuilder|$this|static
+     */
+    public function disableHttpsTransformOnHttpsConnections(): self
+    {
+        $this->needsCompile = $this->httpsTransformOnHttpsConnections !== false;
+        $this->httpsTransformOnHttpsConnections = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable that HTTP sources get converted to HTTPS if the connection is such.
+     *
+     * This is enabled by default
+     *
+     * @return CSPBuilder|$this|static
+     */
+    public function enableHttpsTransformOnHttpsConnections(): self
+    {
+        $this->needsCompile = $this->httpsTransformOnHttpsConnections !== true;
+        $this->httpsTransformOnHttpsConnections = true;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Right now, if the connection is HTTPS every source gets converted to HTTPS aswell. This change adds a switch to disable/toggle that behaviour, keeping it enable as default, though. `upgrade-insecure-requests` still overrides this new setting (=> sources will be converted).

In case anyone in wondering what this is good for I may elaborate my specific use case: 
I am developing an OAuth2 auth-server, that of course is served via an HTTPS connection. This is a [Laravel](https://laravel.com)/[Passport](https://github.com/laravel/passport) application, the *Authorization code* grant redirects to the auth callback of the clients using a form. I am serving CSP headers using this package and add the current `redirect_url` to the *form-src* field. 
Some of the client applications have HTTP `redirect_url`s, though, and as the *form-src* field gets converted to HTTPS the CSP policy blocks the redirect (http://... != https://...).