### PR TITLE
Added manifest-src to list of allowed policies

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -60,6 +60,7 @@ class CSPBuilder
         'media-src',
         'object-src',
         'plugin-types',
+        'manifest-src',
         'script-src',
         'style-src'
     ];


### PR DESCRIPTION
Currently, it is not possible to set this directive (it gets ignored and not added to the compiled CSP string).

It is a thing though: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src - and Chrome indeed uses / checks for it.