### PR TITLE
Employ PHP_CodeSniffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ install:
 script:
     - vendor/bin/phpunit
     - vendor/bin/psalm
+    - vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require-dev": {
         "psr/http-message": "^1",
         "phpunit/phpunit": "4.*|5.*",
+        "squizlabs/php_codesniffer": "^3",
         "vimeo/psalm": "^0.3"
     },
     "suggest": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset>
+    <rule ref="PSR2"/>
+
+    <arg name="colors"/>
+
+    <file>bin</file>
+    <file>src</file>
+    <file>test</file>
+</ruleset>

--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -89,7 +89,7 @@ class CSPBuilder
 
         $compiled = [];
 
-        foreach(self::$directives as $dir) {
+        foreach (self::$directives as $dir) {
             if (\in_array($dir, $ruleKeys)) {
                 if (empty($ruleKeys)) {
                     if ($dir === 'base-uri') {
@@ -278,7 +278,7 @@ class CSPBuilder
     {
         $array = \json_decode($data, true);
 
-        if(!\is_array($array)) {
+        if (!\is_array($array)) {
             throw new \Exception('Is not array valid');
         }
 
@@ -369,7 +369,7 @@ class CSPBuilder
      * @param bool $legacy
      * @return \Psr\Http\Message\MessageInterface
      */
-    function injectCSPHeader(MessageInterface $message, bool $legacy = false): MessageInterface
+    public function injectCSPHeader(MessageInterface $message, bool $legacy = false): MessageInterface
     {
         if ($this->needsCompile) {
             $this->compile();
@@ -596,7 +596,8 @@ class CSPBuilder
                 if ($url !== false) {
                     if ($this->supportOldBrowsers) {
                         if (\strpos($url, '://') === false) {
-                            if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections) || !empty($this->policies['upgrade-insecure-requests'])) {
+                            if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections)
+                                || !empty($this->policies['upgrade-insecure-requests'])) {
                                 // We only want HTTPS connections here.
                                 $ret .= 'https://'.$url.' ';
                             } else {
@@ -604,7 +605,8 @@ class CSPBuilder
                             }
                         }
                     }
-                    if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections) || !empty($this->policies['upgrade-insecure-requests'])) {
+                    if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections)
+                        || !empty($this->policies['upgrade-insecure-requests'])) {
                         $ret .= \str_replace('http://', 'https://', $url).' ';
                     } else {
                         $ret .= $url.' ';

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -1,9 +1,10 @@
 <?php
-use ParagonIE\CSPBuilder\CSPBuilder;
 
-/**
- * 
- */
+namespace ParagonIE\CSPBuilderTest;
+
+use ParagonIE\CSPBuilder\CSPBuilder;
+use PHPUnit_Framework_TestCase;
+
 class BasicTest extends PHPUnit_Framework_TestCase
 {
     public function testBasicFromFile()
@@ -14,7 +15,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
             file_get_contents(__DIR__.'/vectors/basic-csp.out'),
             $basic->getCompiledHeader()
         );
-        
+
         $noOld = file_get_contents(__DIR__.'/vectors/basic-csp-no-old.out');
         // We expect different output for ytimg.com when we disable legacy
         // browser support (i.e. Safari):
@@ -24,7 +25,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
                 ->disableOldBrowserSupport()
                 ->getCompiledHeader()
         );
-        
+
         $array = $basic->getHeaderArray();
         $this->assertEquals(
             $array,
@@ -34,8 +35,8 @@ class BasicTest extends PHPUnit_Framework_TestCase
                 'X-Webkit-CSP' => $noOld
             ]
         );
-        
-        
+
+
         $array2 = $basic->getHeaderArray(false);
         $this->assertEquals(
             $array2,
@@ -48,7 +49,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
     public function testBasicFromData()
     {
         $data = file_get_contents(__DIR__.'/vectors/basic-csp.json');
-        
+
         $basic = CSPBuilder::fromData($data);
         $basic->addSource('img-src', 'ytimg.com');
 
@@ -57,7 +58,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
             $basic->getCompiledHeader()
         );
     }
-    
+
     public function testHash()
     {
         $basic = CSPBuilder::fromFile(__DIR__.'/vectors/basic-csp.json');
@@ -67,7 +68,7 @@ class BasicTest extends PHPUnit_Framework_TestCase
             $basic->getCompiledHeader()
         );
     }
-    
+
     public function testPreHash()
     {
         $basic = CSPBuilder::fromFile(__DIR__.'/vectors/basic-csp.json');
@@ -87,7 +88,8 @@ class BasicTest extends PHPUnit_Framework_TestCase
     public function testSourceHttpsConversion()
     {
         /** @var CSPBuilder|\PHPUnit_Framework_MockObject_MockObject $cspHttp */
-        $cspHttp = $this->getMockBuilder(CSPBuilder::class)->setMethods(['isHTTPSConnection'])->disableOriginalConstructor()->getMock();
+        $cspHttp = $this->getMockBuilder(CSPBuilder::class)->setMethods(['isHTTPSConnection'])
+            ->disableOriginalConstructor()->getMock();
         $cspHttp->method('isHTTPSConnection')->willReturn(false);
 
         $cspHttp->addSource('form', 'http://example.com');
@@ -98,7 +100,8 @@ class BasicTest extends PHPUnit_Framework_TestCase
         $this->assertContains('http://another.com', $compiledCspHttp);
 
         /** @var CSPBuilder|\PHPUnit_Framework_MockObject_MockObject $cspHttps */
-        $cspHttps = $this->getMockBuilder(CSPBuilder::class)->setMethods(['isHTTPSConnection'])->disableOriginalConstructor()->getMock();
+        $cspHttps = $this->getMockBuilder(CSPBuilder::class)->setMethods(['isHTTPSConnection'])
+            ->disableOriginalConstructor()->getMock();
         $cspHttps->method('isHTTPSConnection')->willReturn(true);
 
         $cspHttps->addSource('form', 'http://example.com');


### PR DESCRIPTION
This PR adds support for enforcing code style consistency with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)’s assistance. Currently it’s configured to only use [`PSR2`](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/PSR2/ruleset.xml) set of rules, but it may be better to add more rules (or perhaps something like [Zend Framework Coding Standard](https://github.com/zendframework/zend-coding-standard)).