### PR TITLE
Fix minor edge case with "needsCompile" variable

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -230,7 +230,7 @@ class CSPBuilder
      */
     public function disableOldBrowserSupport(): self
     {
-        $this->needsCompile = $this->supportOldBrowsers !== false;
+        $this->needsCompile = ($this->needsCompile || $this->supportOldBrowsers !== false);
         $this->supportOldBrowsers = false;
         return $this;
     }
@@ -244,7 +244,7 @@ class CSPBuilder
      */
     public function enableOldBrowserSupport(): self
     {
-        $this->needsCompile = $this->supportOldBrowsers !== true;
+        $this->needsCompile = ($this->needsCompile || $this->supportOldBrowsers !== true);
         $this->supportOldBrowsers = true;
         return $this;
     }
@@ -819,7 +819,7 @@ class CSPBuilder
      */
     public function disableHttpsTransformOnHttpsConnections(): self
     {
-        $this->needsCompile = $this->httpsTransformOnHttpsConnections !== false;
+        $this->needsCompile = ($this->needsCompile || $this->httpsTransformOnHttpsConnections !== false);
         $this->httpsTransformOnHttpsConnections = false;
 
         return $this;
@@ -834,7 +834,7 @@ class CSPBuilder
      */
     public function enableHttpsTransformOnHttpsConnections(): self
     {
-        $this->needsCompile = $this->httpsTransformOnHttpsConnections !== true;
+        $this->needsCompile = ($this->needsCompile || $this->httpsTransformOnHttpsConnections !== true);
         $this->httpsTransformOnHttpsConnections = true;
 
         return $this;


### PR DESCRIPTION
Feel free to sanity-check me here, but it seems entirely possible with the current code that one could do something that triggers the "needsCompile" flag to be set to `true`, then call `$csp->enableHttpsTransformOnHttpsConnections()` or some other function that is already set to that same value, after which "needsCompile" would be `false`, even though it's actually still true due to earlier changes.