### PR TITLE
Adds hook before save output

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,19 @@ $policy->saveSnippet(
 
 Make sure you reload your webserver afterwards.
 
+## Processing output before save to disk through hook
+
+```php
+$policy = CSPBuilder::fromFile('/path/to/source.json');
+$policy->saveSnippet(
+    '/etc/nginx/snippets/my-csp.conf',
+    CSPBuilder::FORMAT_NGINX
+    fn ($output) =>  \str_replace('bar','foo',$output)
+);
+```
+
+The output will change before save to file
+
 ## Support Contracts
 
 If your company uses this library in their products or services, you may be

--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -1,7 +1,5 @@
 <?php
-
 declare(strict_types=1);
-
 namespace ParagonIE\CSPBuilder;
 
 use \ParagonIE\ConstantTime\Base64;
@@ -106,7 +104,7 @@ class CSPBuilder
                         continue;
                     }
                 }
-                $compiled[] = $this->compileSubgroup(
+                $compiled []= $this->compileSubgroup(
                     $dir,
                     $this->policies[$dir]
                 );
@@ -117,16 +115,16 @@ class CSPBuilder
             if (!\is_string($this->policies['report-uri'])) {
                 throw new \TypeError('report-uri policy somehow not a string');
             }
-            $compiled[] = 'report-uri ' . $this->policies['report-uri'] . '; ';
+            $compiled [] = 'report-uri ' . $this->policies['report-uri'] . '; ';
         }
         if (!empty($this->policies['report-to'])) {
             if (!\is_string($this->policies['report-to'])) {
                 throw new \TypeError('report-to policy somehow not a string');
             }
-            $compiled[] = 'report-to ' . $this->policies['report-to'] . '; ';
+            $compiled []= 'report-to ' . $this->policies['report-to'] . '; ';
         }
         if (!empty($this->policies['upgrade-insecure-requests'])) {
-            $compiled[] = 'upgrade-insecure-requests';
+            $compiled []= 'upgrade-insecure-requests';
         }
 
         $this->compiled = \implode('', $compiled);
@@ -234,7 +232,7 @@ class CSPBuilder
      */
     public function allowPluginType(string $mime = 'text/plain'): self
     {
-        $this->policies['plugin-types']['types'][] = $mime;
+        $this->policies['plugin-types']['types'] []= $mime;
 
         $this->needsCompile = true;
         return $this;
@@ -306,7 +304,7 @@ class CSPBuilder
     public static function fromFile(string $filename = ''): self
     {
         if (!\file_exists($filename)) {
-            throw new \Exception($filename . ' does not exist');
+            throw new \Exception($filename.' does not exist');
         }
         $contents = \file_get_contents($filename);
         if (!\is_string($contents)) {
@@ -376,7 +374,7 @@ class CSPBuilder
     ): self {
         $ruleKeys = \array_keys($this->policies);
         if (\in_array($directive, $ruleKeys)) {
-            $this->policies[$directive]['hashes'][] = [
+            $this->policies[$directive]['hashes'] []= [
                 $algorithm => Base64::encode(
                     \hash($algorithm, $script, true)
                 )
@@ -402,7 +400,7 @@ class CSPBuilder
             $this->compile();
         }
         foreach ($this->getRequireHeaders() as $header) {
-            list($key, $value) = $header;
+            list ($key, $value) = $header;
             $message = $message->withAddedHeader($key, $value);
         }
         foreach ($this->getHeaderKeys($legacy) as $key) {
@@ -429,7 +427,7 @@ class CSPBuilder
         if (empty($nonce)) {
             $nonce = Base64::encode(\random_bytes(18));
         }
-        $this->policies[$directive]['nonces'][] = $nonce;
+        $this->policies[$directive]['nonces'] []= $nonce;
         return $nonce;
     }
 
@@ -448,7 +446,7 @@ class CSPBuilder
     ): self {
         $ruleKeys = \array_keys($this->policies);
         if (\in_array($directive, $ruleKeys)) {
-            $this->policies[$directive]['hashes'][] = [
+            $this->policies[$directive]['hashes'] []= [
                 $algorithm => $hash
             ];
         }
@@ -512,7 +510,7 @@ class CSPBuilder
                 ]);
                 break;
             default:
-                throw new \Exception('Unknown format: ' . $format);
+                throw new \Exception('Unknown format: '.$format);
         }
 
         if ($hookBeforeSave !== null) {
@@ -539,11 +537,11 @@ class CSPBuilder
             $this->compile();
         }
         foreach ($this->getRequireHeaders() as $header) {
-            list($key, $value) = $header;
-            \header($key . ': ' . $value);
+            list ($key, $value) = $header;
+            \header($key.': '.$value);
         }
         foreach ($this->getHeaderKeys($legacy) as $key) {
-            \header($key . ': ' . $this->compiled);
+            \header($key.': '.$this->compiled);
         }
         return true;
     }
@@ -753,7 +751,7 @@ class CSPBuilder
         $this->policies['report-uri'] = $url;
         return $this;
     }
-
+    
     /**
      * Set the report-to directive to the desired string.
      *
@@ -783,16 +781,16 @@ class CSPBuilder
             if ($directive === 'plugin-types') {
                 return '';
             } elseif ($directive === 'sandbox') {
-                return $directive . '; ';
+                return $directive.'; ';
             }
-            return $directive . " 'none'; ";
+            return $directive." 'none'; ";
         }
         /** @var array<array-key, mixed> $policies */
 
-        $ret = $directive . ' ';
+        $ret = $directive.' ';
         if ($directive === 'plugin-types') {
             // Expects MIME types, not URLs
-            return $ret . \implode(' ', $policies['allow']) . '; ';
+            return $ret . \implode(' ', $policies['allow']).'; ';
         }
         if (!empty($policies['self'])) {
             $ret .= "'self' ";
@@ -808,21 +806,19 @@ class CSPBuilder
                     if ($this->supportOldBrowsers && $directive !== 'sandbox') {
                         if (\strpos($url, '://') === false) {
                             if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections)
-                                || !empty($this->policies['upgrade-insecure-requests'])
-                            ) {
+                                || !empty($this->policies['upgrade-insecure-requests'])) {
                                 // We only want HTTPS connections here.
-                                $ret .= 'https://' . $url . ' ';
+                                $ret .= 'https://'.$url.' ';
                             } else {
-                                $ret .= 'https://' . $url . ' http://' . $url . ' ';
+                                $ret .= 'https://'.$url.' http://'.$url.' ';
                             }
                         }
                     }
                     if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections)
-                        || !empty($this->policies['upgrade-insecure-requests'])
-                    ) {
-                        $ret .= \str_replace('http://', 'https://', $url) . ' ';
+                        || !empty($this->policies['upgrade-insecure-requests'])) {
+                        $ret .= \str_replace('http://', 'https://', $url).' ';
                     } else {
-                        $ret .= $url . ' ';
+                        $ret .= $url.' ';
                     }
                 }
             }
@@ -895,7 +891,7 @@ class CSPBuilder
         if (!empty($policies['unsafe-hashed-attributes'])) {
             $ret .= "'unsafe-hashed-attributes' ";
         }
-        return \rtrim($ret, ' ') . '; ';
+        return \rtrim($ret, ' ').'; ';
     }
 
     /**
@@ -915,10 +911,10 @@ class CSPBuilder
 
         // If we're supporting legacy devices, include these too:
         if ($legacy) {
-            $return[] = $this->reportOnly
+            $return []= $this->reportOnly
                 ? 'X-Content-Security-Policy-Report-Only'
                 : 'X-Content-Security-Policy';
-            $return[] = $this->reportOnly
+            $return []= $this->reportOnly
                 ? 'X-Webkit-CSP-Report-Only'
                 : 'X-Webkit-CSP';
         }

--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -514,8 +514,8 @@ class CSPBuilder
             default:
                 throw new \Exception('Unknown format: ' . $format);
         }
-        
-        if ($hookBeforeSave !== null ) {
+
+        if ($hookBeforeSave !== null) {
             $output = $hookBeforeSave($output);
         }
 

--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace ParagonIE\CSPBuilder;
 
 use \ParagonIE\ConstantTime\Base64;
@@ -104,7 +106,7 @@ class CSPBuilder
                         continue;
                     }
                 }
-                $compiled []= $this->compileSubgroup(
+                $compiled[] = $this->compileSubgroup(
                     $dir,
                     $this->policies[$dir]
                 );
@@ -115,16 +117,16 @@ class CSPBuilder
             if (!\is_string($this->policies['report-uri'])) {
                 throw new \TypeError('report-uri policy somehow not a string');
             }
-            $compiled [] = 'report-uri ' . $this->policies['report-uri'] . '; ';
+            $compiled[] = 'report-uri ' . $this->policies['report-uri'] . '; ';
         }
         if (!empty($this->policies['report-to'])) {
             if (!\is_string($this->policies['report-to'])) {
                 throw new \TypeError('report-to policy somehow not a string');
             }
-            $compiled []= 'report-to ' . $this->policies['report-to'] . '; ';
+            $compiled[] = 'report-to ' . $this->policies['report-to'] . '; ';
         }
         if (!empty($this->policies['upgrade-insecure-requests'])) {
-            $compiled []= 'upgrade-insecure-requests';
+            $compiled[] = 'upgrade-insecure-requests';
         }
 
         $this->compiled = \implode('', $compiled);
@@ -232,7 +234,7 @@ class CSPBuilder
      */
     public function allowPluginType(string $mime = 'text/plain'): self
     {
-        $this->policies['plugin-types']['types'] []= $mime;
+        $this->policies['plugin-types']['types'][] = $mime;
 
         $this->needsCompile = true;
         return $this;
@@ -304,7 +306,7 @@ class CSPBuilder
     public static function fromFile(string $filename = ''): self
     {
         if (!\file_exists($filename)) {
-            throw new \Exception($filename.' does not exist');
+            throw new \Exception($filename . ' does not exist');
         }
         $contents = \file_get_contents($filename);
         if (!\is_string($contents)) {
@@ -374,7 +376,7 @@ class CSPBuilder
     ): self {
         $ruleKeys = \array_keys($this->policies);
         if (\in_array($directive, $ruleKeys)) {
-            $this->policies[$directive]['hashes'] []= [
+            $this->policies[$directive]['hashes'][] = [
                 $algorithm => Base64::encode(
                     \hash($algorithm, $script, true)
                 )
@@ -400,7 +402,7 @@ class CSPBuilder
             $this->compile();
         }
         foreach ($this->getRequireHeaders() as $header) {
-            list ($key, $value) = $header;
+            list($key, $value) = $header;
             $message = $message->withAddedHeader($key, $value);
         }
         foreach ($this->getHeaderKeys($legacy) as $key) {
@@ -427,7 +429,7 @@ class CSPBuilder
         if (empty($nonce)) {
             $nonce = Base64::encode(\random_bytes(18));
         }
-        $this->policies[$directive]['nonces'] []= $nonce;
+        $this->policies[$directive]['nonces'][] = $nonce;
         return $nonce;
     }
 
@@ -446,7 +448,7 @@ class CSPBuilder
     ): self {
         $ruleKeys = \array_keys($this->policies);
         if (\in_array($directive, $ruleKeys)) {
-            $this->policies[$directive]['hashes'] []= [
+            $this->policies[$directive]['hashes'][] = [
                 $algorithm => $hash
             ];
         }
@@ -475,7 +477,8 @@ class CSPBuilder
      */
     public function saveSnippet(
         string $outputFile,
-        string $format = self::FORMAT_NGINX
+        string $format = self::FORMAT_NGINX,
+        callable $hookBeforeSave = null
     ): bool {
         if ($this->needsCompile) {
             $this->compile();
@@ -509,8 +512,13 @@ class CSPBuilder
                 ]);
                 break;
             default:
-                throw new \Exception('Unknown format: '.$format);
+                throw new \Exception('Unknown format: ' . $format);
         }
+        
+        if ($hookBeforeSave !== null ) {
+            $output = $hookBeforeSave($output);
+        }
+
         return \file_put_contents($outputFile, $output) !== false;
     }
 
@@ -531,11 +539,11 @@ class CSPBuilder
             $this->compile();
         }
         foreach ($this->getRequireHeaders() as $header) {
-            list ($key, $value) = $header;
-            \header($key.': '.$value);
+            list($key, $value) = $header;
+            \header($key . ': ' . $value);
         }
         foreach ($this->getHeaderKeys($legacy) as $key) {
-            \header($key.': '.$this->compiled);
+            \header($key . ': ' . $this->compiled);
         }
         return true;
     }
@@ -745,7 +753,7 @@ class CSPBuilder
         $this->policies['report-uri'] = $url;
         return $this;
     }
-    
+
     /**
      * Set the report-to directive to the desired string.
      *
@@ -775,16 +783,16 @@ class CSPBuilder
             if ($directive === 'plugin-types') {
                 return '';
             } elseif ($directive === 'sandbox') {
-                return $directive.'; ';
+                return $directive . '; ';
             }
-            return $directive." 'none'; ";
+            return $directive . " 'none'; ";
         }
         /** @var array<array-key, mixed> $policies */
 
-        $ret = $directive.' ';
+        $ret = $directive . ' ';
         if ($directive === 'plugin-types') {
             // Expects MIME types, not URLs
-            return $ret . \implode(' ', $policies['allow']).'; ';
+            return $ret . \implode(' ', $policies['allow']) . '; ';
         }
         if (!empty($policies['self'])) {
             $ret .= "'self' ";
@@ -800,19 +808,21 @@ class CSPBuilder
                     if ($this->supportOldBrowsers && $directive !== 'sandbox') {
                         if (\strpos($url, '://') === false) {
                             if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections)
-                                || !empty($this->policies['upgrade-insecure-requests'])) {
+                                || !empty($this->policies['upgrade-insecure-requests'])
+                            ) {
                                 // We only want HTTPS connections here.
-                                $ret .= 'https://'.$url.' ';
+                                $ret .= 'https://' . $url . ' ';
                             } else {
-                                $ret .= 'https://'.$url.' http://'.$url.' ';
+                                $ret .= 'https://' . $url . ' http://' . $url . ' ';
                             }
                         }
                     }
                     if (($this->isHTTPSConnection() && $this->httpsTransformOnHttpsConnections)
-                        || !empty($this->policies['upgrade-insecure-requests'])) {
-                        $ret .= \str_replace('http://', 'https://', $url).' ';
+                        || !empty($this->policies['upgrade-insecure-requests'])
+                    ) {
+                        $ret .= \str_replace('http://', 'https://', $url) . ' ';
                     } else {
-                        $ret .= $url.' ';
+                        $ret .= $url . ' ';
                     }
                 }
             }
@@ -885,7 +895,7 @@ class CSPBuilder
         if (!empty($policies['unsafe-hashed-attributes'])) {
             $ret .= "'unsafe-hashed-attributes' ";
         }
-        return \rtrim($ret, ' ').'; ';
+        return \rtrim($ret, ' ') . '; ';
     }
 
     /**
@@ -905,10 +915,10 @@ class CSPBuilder
 
         // If we're supporting legacy devices, include these too:
         if ($legacy) {
-            $return []= $this->reportOnly
+            $return[] = $this->reportOnly
                 ? 'X-Content-Security-Policy-Report-Only'
                 : 'X-Content-Security-Policy';
-            $return []= $this->reportOnly
+            $return[] = $this->reportOnly
                 ? 'X-Webkit-CSP-Report-Only'
                 : 'X-Webkit-CSP';
         }

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -2,10 +2,8 @@
 
 namespace ParagonIE\CSPBuilderTest;
 
-use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\CSPBuilder\CSPBuilder;
-use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -2,8 +2,10 @@
 
 namespace ParagonIE\CSPBuilderTest;
 
-use ParagonIE\CSPBuilder\CSPBuilder;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use ParagonIE\CSPBuilder\CSPBuilder;
+use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -263,4 +265,46 @@ class BasicTest extends TestCase
         $this->assertStringContainsString('frame-ancestors https://example.com', $compiled);
         $this->assertStringNotContainsString('style-src https://example.com', $compiled);
     }
+
+    public function testSaveSnippetWithHookBeforeSave()
+    {
+        $data = \file_get_contents(__DIR__ . '/vectors/basic-csp.json');
+
+        $basic = CSPBuilder::fromData($data);
+        $basic->addSource('img-src', 'ytimg.com');
+
+        $tempfile = tempnam(sys_get_temp_dir(), '');
+
+        $basic->saveSnippet(
+            $tempfile,
+            CSPBuilder::FORMAT_NGINX,
+            fn ($output) =>  \str_replace('ytimg','foo',$output)
+        );
+
+        $this->assertStringContainsString(
+            "img-src 'self' https://foo.com",
+            \file_get_contents($tempfile)
+        );
+    }
+
+    public function testSaveSnippetWithoutHookBeforeSave()
+    {
+        $data = \file_get_contents(__DIR__ . '/vectors/basic-csp.json');
+
+        $basic = CSPBuilder::fromData($data);
+        $basic->addSource('img-src', 'ytimg.com');
+
+        $tempfile = tempnam(sys_get_temp_dir(), '');
+
+        $basic->saveSnippet(
+            $tempfile,
+            CSPBuilder::FORMAT_NGINX
+        );
+
+        $this->assertStringContainsString(
+            "img-src 'self' https://ytimg.com",
+            \file_get_contents($tempfile)
+        );
+    }
+
 }

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -276,7 +276,9 @@ class BasicTest extends TestCase
         $basic->saveSnippet(
             $tempfile,
             CSPBuilder::FORMAT_NGINX,
-            fn ($output) =>  \str_replace('ytimg','foo',$output)
+            function  ($output) {
+                return \str_replace('ytimg', 'foo', $output);
+            }  
         );
 
         $this->assertStringContainsString(


### PR DESCRIPTION
In some situations, we need to process the output before saving it to disk. This PR adds an extension point for this purpose.

In my specific case, I use the generated output for NGINX by 
following the approach suggested by Scott Helme in this post
https://scotthelme.co.uk/csp-nonce-support-in-nginx.

So the nonce must be `nonce-$some-placeholder-value`
but the nonce value in `csp-builder` is sanitized with a regexp (it's ok) but this forces to apply transformations after that the file it's saves to disk. 

I work around it reloads the file after saving and apply the correct fixes. 

With this extension point, it's possible to use this lib and follows this approach in an elegant manner, further, it's possible to "patch" the file in all cases in which some directives must be yet integrated 