### PR TITLE
report-uri should not be encoded at all

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -137,7 +137,7 @@ class CSPBuilder
             if (!is_string($this->policies['report-uri'])) {
                 throw new TypeError('report-uri policy somehow not a string');
             }
-            $compiled [] = 'report-uri ' . $this->enc($this->policies['report-uri'], 'url') . '; ';
+            $compiled [] = 'report-uri ' . $this->policies['report-uri'] . '; ';
         }
         if (!empty($this->policies['report-to'])) {
             if (!is_string($this->policies['report-to'])) {


### PR DESCRIPTION
The report-uri should, as report-to, be unencoded.

If any encoding happens on those URLs, the endpoint is parsed as `current.website/{encoded-report-endpoint}`