### PR TITLE
Generate nonce also when only `default-src` policy is applied

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -453,7 +453,7 @@ class CSPBuilder
     public function nonce(string $directive = 'script-src', string $nonce = ''): string
     {
         $ruleKeys = array_keys($this->policies);
-        if (!in_array($directive, $ruleKeys)) {
+        if (!in_array($directive, $ruleKeys) && !in_array('default-src', $ruleKeys)) {
             return '';
         }
 

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -254,6 +254,10 @@ class BasicTest extends TestCase
     public function testNonce()
     {
         $csp = new CSPBuilder();
+
+        $this->assertEmpty($csp->nonce('script-src'));
+        $this->assertEmpty($csp->nonce('style-src'));
+
         $csp->setSelfAllowed('script-src', true);
         $csp->setSelfAllowed('style-src', true);
 

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -248,6 +248,33 @@ class BasicTest extends TestCase
     }
 
     /**
+     * @covers CSPBuilder::nonce()
+     * @throws \Exception
+     */
+    public function testNonce()
+    {
+        $csp = new CSPBuilder();
+        $csp->setSelfAllowed('script-src', true);
+        $csp->setSelfAllowed('style-src', true);
+
+        $this->assertNotEmpty($csp->nonce('script-src'));
+        $this->assertNotEmpty($csp->nonce('style-src'));
+    }
+
+    /**
+     * @covers CSPBuilder::nonce()
+     * @throws \Exception
+     */
+    public function testNonceWithDefaultSrc()
+    {
+        $csp = new CSPBuilder();
+        $csp->setSelfAllowed('default-src', true);
+
+        $this->assertNotEmpty($csp->nonce('script-src'));
+        $this->assertNotEmpty($csp->nonce('style-src'));
+    }
+
+    /**
      * @covers \ParagonIE\CSPBuilder\CSPBuilder
      */
     public function testSandbox()


### PR DESCRIPTION
Consider the following example:

```php
$csp = new CSPBuilder();
$csp->setSelfAllowed('default-src', true);
$nonce = $csp->getNonce('script-src');
$csp->sendCSPHeader(false);
echo '<script nonce="'.$nonce.'">…</script>';
```

This will send:

```
Content-Security-Policy: default-src 'self'; 
```
```html
<script nonce="">…</script>
```

Due to the `default-src 'self'` CSP the `<script>` will not be executed since there is no nonce.

This PR would also check for a `default-src` policy so that the response will be:

```
Content-Security-Policy: default-src 'self'; script-src 'nonce-cFYyNld/10nnE2MH59DvbkuL'; 
```
```html
<script nonce="cFYyNld/10nnE2MH59DvbkuL">…</script>
```