### PR TITLE
Remove trailing semicolon

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -149,7 +149,7 @@ class CSPBuilder
             $compiled []= 'upgrade-insecure-requests';
         }
 
-        $this->compiled = implode('', $compiled);
+        $this->compiled = rtrim(implode('', $compiled), '; ');
         $this->needsCompile = false;
         return $this->compiled;
     }

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -73,6 +73,23 @@ class BasicTest extends TestCase
     /**
      * @throws \Exception
      */
+    public function testNoTrailingSemicolon()
+    {
+        $csp = (new CSPBuilder())
+            ->setSelfAllowed('default-src', true)
+            ->addSource('img-src', 'ytimg.com')
+            ->disableOldBrowserSupport()
+        ;
+
+        $this->assertEquals(
+            "default-src 'self'; img-src ytimg.com",
+            $csp->getCompiledHeader()
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
     public function testHash()
     {
         $basic = CSPBuilder::fromFile(__DIR__.'/vectors/basic-csp.json');


### PR DESCRIPTION
Currently a CSP like this:

```php
$csp = (new CSPBuilder())
    ->setSelfAllowed('default-src', true)
    ->addSource('img-src', 'ytimg.com')
    ->disableOldBrowserSupport()
;
```

will produce a header like this:

```
default-src 'self'; img-src ytimg.com; 
```

i.e. if you do not have directives like `upgrade-insecure-requests` then there will always be a trailing semicolon (and space). While this does not lead to any issues if you use this header as is, it is still inconsistent and unexpected imho. This PR would always remove the trailing semicolon and space.