### PR TITLE
Ignore PHPUnit result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 /composer.lock
 /composer.phar
+.phpunit.result.cache


### PR DESCRIPTION
When running `vendor/bin/phpunit` PHPUnit will create a `.phpunit.result.cache` files in the working directory - a file that should not be committed to the repository. This PR adds `.phpunit.result.cache` to the `.gitignore`.