### PR TITLE
Allow 'unsafe-hashed-attributes' to be set

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -614,6 +614,23 @@ class CSPBuilder
     }
 
     /**
+     * Allow/disallow unsafe-hashed-attributes within a given directive.
+     *
+     * @param string $directive
+     * @param bool $allow
+     * @return self
+     * @throws Exception
+     */
+    public function setAllowUnsafeHashedAttributes(string $directive = '', bool $allow = false): self
+    {
+        if (!in_array($directive, self::$directives)) {
+            throw new Exception('Directive ' . $directive . ' does not exist');
+        }
+        $this->policies[$directive]['unsafe-hashed-attributes'] = $allow;
+        return $this;
+    }
+
+    /**
      * Allow/disallow blob: URIs for a given directive
      *
      * @param string $directive

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -334,4 +334,16 @@ class BasicTest extends TestCase
         );
     }
 
+    /**
+     * @covers CSPBuilder::setAllowUnsafeEval()
+     * @throws \Exception
+     */
+    public function testAllowUnsafeHashedAttributes()
+    {
+        $csp = new CSPBuilder();
+        $csp->setAllowUnsafeHashedAttributes('script-src', true);
+        $compiled = $csp->compile();
+
+        $this->assertStringContainsString("'unsafe-hashed-attributes'", $compiled);
+    }
 }


### PR DESCRIPTION
The `CSPBuilder` supports `'unsafe-hashed-attributes'` when reading from an existing JSON. However, there is currently no way to actually set this programmatically. This PR enables that feature.