### PR TITLE
Fix `plugin-types` generation

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -872,7 +872,8 @@ class CSPBuilder
         $ret = $this->enc($directive) . ' ';
         if ($directive === 'plugin-types') {
             // Expects MIME types, not URLs
-            return $ret . $this->enc(implode(' ', $policies['allow']), 'mime').'; ';
+            $types = trim($this->enc(implode(' ', $policies['types']), 'mime'));
+            return $types ? $ret . $types . '; ' : '';
         }
         if (!empty($policies['self'])) {
             $ret .= "'self' ";
@@ -1018,7 +1019,10 @@ class CSPBuilder
     {
         switch ($type) {
             case 'mime':
-                return preg_replace('#^[a-z0-9\-/]+#', '', strtolower($piece));
+                if (preg_match('#^([a-z0-9\-/]+)#', $piece, $matches)) {
+                    return $matches[1];
+                }
+                return '';
             case 'url':
                 return urlencode($piece);
             default:

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -334,4 +334,18 @@ class BasicTest extends TestCase
         );
     }
 
+    /**
+     * @covers CSPBuilder::allowPluginType()
+     * @throws \Exception
+     */
+    public function testAllowPluginType()
+    {
+        $csp = new CSPBuilder();
+        $csp->allowPluginType('application/x-java-applet');
+        $csp->allowPluginType('something/$&§invalid');
+        $compiled = $csp->compile();
+
+        $this->assertStringContainsString('plugin-types application/x-java-applet', $compiled);
+        $this->assertStringNotContainsString('something', $compiled);
+    }
 }


### PR DESCRIPTION
Currently `CSPBuilder::allowPluginType` does not work at all. There are two issues:

1. `compileSubgroup` tries to compile the allowed plugin types from the `allow` sub-key. However that key does not exist, leading to
    ```
    1) ParagonIE\CSPBuilderTest\BasicTest::testAllowPluginType
    Undefined array key "allow"
    
    csp-builder\src\CSPBuilder.php:875
    csp-builder\src\CSPBuilder.php:131
    ```
    The allowed plugin types are actually stored in the `types` sub-key.
2. The `preg_replace` in `enc` will actually _remove_ any valid mime type string.

This PR implements the following changes:

1. The allowed plugin types are now retrieved from the correct array sub-key.
2. The `enc` method for `mime` strings is changed to a `preg_match` method that will return a valid mime-type definition if found and an empty string if not.
3. The `compileSubgroup` will return an empty string if no valid plugin type was provided.