### PR TITLE
Add PoC of report-to header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "php": "^7.1|^8",
         "ext-json": "*",
         "paragonie/constant_time_encoding": "^2",
-        "psr/http-message": "^1|^2"
+        "psr/http-message": "^1|^2",
+        "opis/json-schema": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7|^8|^9|^10",

--- a/schema/reportto.json
+++ b/schema/reportto.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/ReportTo",
+  "definitions": {
+    "ReportTo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "max_age": {
+          "type": "integer"
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Endpoint"
+          }
+        },
+        "include_subdomains": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "endpoints",
+        "group",
+        "max_age"
+      ],
+      "title": "ReportTo"
+    },
+    "Endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": [
+            "https"
+          ]
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "title": "Endpoint"
+    }
+  }
+}


### PR DESCRIPTION
This is a proof-of-concept of adding a report-to header, resolving issue #63 

To do:
- Ensure the correct header is set in the actual CSP header. It should be the name of the group.
- Tests
- Code unification to make methods etc. have a similar name
- Documentation


Feedback welcome!