### PR TITLE
Add support for `psr/http-message` v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": "^7.1|^8",
         "ext-json": "*",
         "paragonie/constant_time_encoding": "^2",
-        "psr/http-message": "^1"
+        "psr/http-message": "^1|^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7|^8|^9",


### PR DESCRIPTION
This PR adds support for `psr/http-message` v2. No changes to code or tests are necessary as the primary change is that `getBody` now returns a `StreamInterface` instead of a `string`. Since this package only touches the headers, support for v2 requires no additional changes.