### PR TITLE
un-deprecate `frame-src`

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -171,6 +171,14 @@ class CSPBuilder
         $this->needsCompile = true;
         switch ($directive) {
             case 'child':
+            case 'child-src':
+                if ($this->supportOldBrowsers) {
+                    $this->policies['child-src']['allow'][] = $path;
+                    $this->policies['frame-src']['allow'][] = $path;
+                    return $this;
+                }
+                $directive = 'child-src';
+                break;
             case 'frame':
             case 'frame-src':
                 if ($this->supportOldBrowsers) {
@@ -178,7 +186,7 @@ class CSPBuilder
                     $this->policies['frame-src']['allow'][] = $path;
                     return $this;
                 }
-                $directive = 'child-src';
+                $directive = 'frame-src';
                 break;
             case 'connect':
             case 'socket':


### PR DESCRIPTION
Currently the `CSPBuilder` automatically adds both `frame-src` and `child-src` when using `frame-src` as `frame-src` was originally deprecated in CSP Level 2. However, in CSP Level 3 `frame-src` has been un-deprecated again and `frame-src` is now the preferred way of defining allowed iframe sources.

So I think the correct way to handle this within the `CSPBuilder` is to always add both `child-src` and `frame-src` for either one, if `supportOldBrowsers` is enabled.

The CSP Level 3 standard defines that you should use preferably either `frame-src` or `worker-src` (they did not however deprecate `child-src` technically, if I got that right).