### PR TITLE
Prevent duplicated entries in policies

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -1109,7 +1109,7 @@ class CSPBuilder
         if (!empty($policies['allow'])) {
             /** @var array<array-key, string> $allowedPolicies */
             $allowedPolicies = $policies['allow'];
-            foreach ($allowedPolicies as $url) {
+            foreach (array_unique($allowedPolicies) as $url) {
                 /** @var string|bool $url */
                 $url = filter_var($url, FILTER_SANITIZE_URL);
                 if (is_string($url)) {


### PR DESCRIPTION
When building from aggregated violations, the list of allowed domains will contain many duplicate entries. This PR is the most simple fix to remove the duplication.

Preferably, a `public function hasSource(string $directive, string $path): bool` would be available to prevent adding in the first place, but array_unique will do the trick for now.