### PR TITLE
add updates for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "php": "^7.4|^8",
         "ext-json": "*",
-        "paragonie/constant_time_encoding": "^2",
+        "paragonie/constant_time_encoding": "^2|^3",
         "psr/http-message": "^1|^2",
         "opis/json-schema": "^2.3"
     },

--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -686,7 +686,7 @@ class CSPBuilder
     public function saveSnippet(
         string $outputFile,
         string $format = self::FORMAT_NGINX,
-        callable $hookBeforeSave = null
+        ?callable $hookBeforeSave = null
     ): bool {
         if ($this->needsCompile) {
             $this->compile();


### PR DESCRIPTION
### Feature

* Remove implicitly null typehint from ```CspBuilder``` (deprecated in PHP 8.4; not a breaking change for projects supporting <= PHP 7.0)
* Allow version 3 of ```paragonie/constant-time-encoding``` (used for base64 encoding/decoding safe from timing attacks), which has already been updated for PHP 8.4

### Testing

Unit tests + Psalm analysis pass