### PR TITLE
Add getPolicies method to CSPBuilder class

### DIFF
--- a/src/CSPBuilder.php
+++ b/src/CSPBuilder.php
@@ -125,6 +125,14 @@ class CSPBuilder
     }
 
     /**
+     * @return array The policies array as is.
+     */
+    public function getPolicies(): array
+    {
+        return $this->policies;
+    }
+
+    /**
      * Compile the current policies into a CSP header
      *
      * @return string


### PR DESCRIPTION
@paragonie-scott Small PR to add a getter.

My usecase is to get the policies as an array to output to debug. Current option is to call `exportPolicies` and json_decode it, this is to stop that unnecessary logic.

Otherwise use cases may be to check something post build.